### PR TITLE
fix: 加固桌面端，修复命令注入、路径穿越与不安全 IPC

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -67,7 +67,7 @@ import {
   rmSync,
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -1155,6 +1155,16 @@ async function openCreatePullRequest(cwd: string): Promise<void> {
     const draft = git.draftPr ? "&merge_request[draft]=true" : "";
     url = `${url}/-/merge_requests/new?merge_request[source_branch]=${encodeURIComponent(branch)}${draft}`;
   }
+  // 协议白名单：与 open-external 一致，防止 git remote 被篡改后触发任意协议。
+  let protocol: string;
+  try {
+    protocol = new URL(url).protocol;
+  } catch {
+    throw new Error("无效的 PR 地址");
+  }
+  if (!["http:", "https:", "mailto:"].includes(protocol)) {
+    throw new Error(`不支持的协议: ${protocol}`);
+  }
   await shell.openExternal(url);
 }
 
@@ -1785,7 +1795,33 @@ async function writeMcpConfig(config: McpConfig): Promise<void> {
   const mcpPath = join(agentDir, "mcp.json");
   writeFileSync(mcpPath, JSON.stringify(config, null, 2) + "\n", "utf8");
 }
+/** npm 包名白名单：仅允许合法、URL 安全、不含 shell 元字符的包名（支持 scoped 包）。 */
+const NPM_PACKAGE_NAME_RE = /^(@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/;
 
+function isValidNpmPackageName(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= 214 &&
+    NPM_PACKAGE_NAME_RE.test(value)
+  );
+}
+
+function assertNpmPackageName(value: unknown): string {
+  if (!isValidNpmPackageName(value)) throw new Error("非法的 npm 包名");
+  return value;
+}
+
+/** 仅信任主窗口顶层 frame 发起的 IPC，拒绝子 frame / 外部内容。 */
+function assertTrustedSender(event: Electron.IpcMainInvokeEvent): void {
+  const win = mainWindow;
+  if (!win || win.isDestroyed() || event.sender !== win.webContents) {
+    throw new Error("不受信任的 IPC 发送方");
+  }
+  if (event.senderFrame !== win.webContents.mainFrame) {
+    throw new Error("不受信任的 IPC frame");
+  }
+}
 /**
  * On Windows, npx-resolver in pi-mcp-adapter misidentifies Unix shell scripts
  * in .bin/ as binaries, causing cmd.exe chain breaks that kill stdio pipes.
@@ -1803,6 +1839,7 @@ async function resolveMcpNodeEntry(
   packageName: string,
 ): Promise<{ command: string; args: string[]; cwd: string } | null> {
   if (process.platform !== "win32") return null;
+  assertNpmPackageName(packageName);
   const agentDir = defaultAgentDir();
   const mcpPackagesDir = join(agentDir, "mcp-packages");
   try {
@@ -1861,7 +1898,8 @@ async function openInApp(appId: string, cwd: string): Promise<void> {
     if (found.kind === "terminal") {
       if (found.id === "terminal") {
         // Apple Terminal via AppleScript so cwd is applied.
-        const script = `tell application "Terminal" to do script "cd ${cwd.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+        // `quoted form of` 让 shell 安全引用路径，杜绝 `$()` / 反引号 / `;` 等注入。
+        const script = `tell application "Terminal" to do script "cd " & quoted form of "${cwd.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
         await execFileAsync("osascript", ["-e", script], { windowsHide: true });
         return;
       }
@@ -1872,13 +1910,13 @@ async function openInApp(appId: string, cwd: string): Promise<void> {
     tell current window
       create tab with default profile
       tell current session
-        write text "cd ${cwd.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"
+        write text "cd " & quoted form of "${cwd.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"
       end tell
     end tell
   on error
     create window with default profile
     tell current session of current window
-      write text "cd ${cwd.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"
+      write text "cd " & quoted form of "${cwd.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"
     end tell
   end try
 end tell`;
@@ -1891,25 +1929,23 @@ end tell`;
   }
   if (process.platform === "win32") {
     if (found.id === "wt") {
-      await execFileAsync("wt", ["-d", cwd], { windowsHide: true, shell: true });
+      await execFileAsync("wt", ["-d", cwd], { windowsHide: true });
       return;
     }
     if (found.id === "cmd") {
-      await execFileAsync("cmd", ["/c", "start", "cmd", "/k", `cd /d ${cwd}`], {
+      // 用 cwd 选项让新窗口继承工作目录，避免把路径拼进 shell 命令。
+      await execFileAsync("cmd", ["/c", "start", "", "cmd", "/k"], {
+        cwd,
         windowsHide: true,
-        shell: true,
       });
       return;
     }
     if (found.id === "powershell") {
-      await execFileAsync(
-        "powershell",
-        ["-NoExit", "-Command", `Set-Location -LiteralPath '${cwd.replace(/'/g, "''")}'`],
-        { windowsHide: true, shell: true },
-      );
+      // 用 cwd 选项设置工作目录，去掉 -Command + shell 拼接。
+      await execFileAsync("powershell", ["-NoExit"], { cwd, windowsHide: true });
       return;
     }
-    await execFileAsync(found.target, [cwd], { windowsHide: true, shell: true });
+    await execFileAsync(found.target, [cwd], { windowsHide: true });
     return;
   }
   if (found.kind === "terminal") {
@@ -4652,6 +4688,31 @@ async function createWindow(): Promise<void> {
       preload: join(currentDirectory, "..", "preload", "preload.cjs"),
     },
   });
+
+  // 安全：阻止主 frame 导航离开应用入口，避免 preload 暴露的 IPC 面落到外部站点。
+  const devServerOrigin = (() => {
+    const u = process.env.VITE_DEV_SERVER_URL;
+    if (!u) return undefined;
+    try {
+      return new URL(u).origin;
+    } catch {
+      return undefined;
+    }
+  })();
+  mainWindow.webContents.on("will-navigate", (event, url) => {
+    const ok = devServerOrigin
+      ? (() => {
+          try {
+            return new URL(url).origin === devServerOrigin;
+          } catch {
+            return false;
+          }
+        })()
+      : url.startsWith("file:");
+    if (!ok) event.preventDefault();
+  });
+  mainWindow.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+
   applyAppScale(mainWindow, normalizeAppScale(desktopPrefs.appScale));
   attachWindowBoundsPersistence(mainWindow);
   const emitWindowState = () => {
@@ -5259,12 +5320,14 @@ void app
     ipcMain.handle("zeno:workspace:reveal-in-folder", (_event, cwd: string) => {
       if (typeof cwd === "string" && cwd.trim()) shell.showItemInFolder(cwd);
     });
-    ipcMain.handle("zeno:workspace:open-file", async (_event, path: string) => {
+    ipcMain.handle("zeno:workspace:open-file", async (event, path: string) => {
+      assertTrustedSender(event);
       if (typeof path !== "string" || !path.trim()) throw new Error("Invalid file path");
       const error = await shell.openPath(path);
       if (error) throw new Error(error);
     });
-    ipcMain.handle("zeno:workspace:open-external", async (_event, url: string) => {
+    ipcMain.handle("zeno:workspace:open-external", async (event, url: string) => {
+      assertTrustedSender(event);
       if (typeof url !== "string") throw new Error("Invalid external URL");
       const protocol = new URL(url).protocol;
       if (!new Set(["http:", "https:", "mailto:"]).has(protocol)) {
@@ -5363,8 +5426,12 @@ void app
         const dir = join(app.getPath("temp"), "zeno-attachments");
         mkdirSync(dir, { recursive: true });
         let buffer: Buffer | undefined;
-        let ext =
-          typeof options?.ext === "string" && options.ext.trim() ? options.ext.trim() : "png";
+        const rawExt =
+          typeof options?.ext === "string" && options.ext.trim()
+            ? options.ext.trim().replace(/^\./, "")
+            : "png";
+        // 扩展名白名单：仅字母数字，杜绝路径穿越与非法后缀。
+        let ext = /^[a-z0-9]{1,10}$/i.test(rawExt) ? rawExt.toLowerCase() : "png";
         if (Array.isArray(options?.bytes) && options.bytes.length > 0) {
           buffer = Buffer.from(options.bytes);
         } else {
@@ -5374,16 +5441,26 @@ void app
           ext = "png";
         }
         if (!buffer || buffer.length === 0) return undefined;
-        const filePath = join(dir, `paste-${Date.now()}.${ext.replace(/^\./, "")}`);
+        const filePath = join(dir, `paste-${Date.now()}.${ext}`);
         writeFileSync(filePath, buffer);
         return filePath;
       },
     );
     /** Local image → small data-URL thumbnail for AttachmentMedia variant="image". */
-    ipcMain.handle("zeno:workspace:read-attachment-preview", async (_event, filePath?: string) => {
+    ipcMain.handle("zeno:workspace:read-attachment-preview", async (event, filePath?: string) => {
+      assertTrustedSender(event);
       if (typeof filePath !== "string" || !filePath.trim()) return undefined;
-      const abs = isAbsolute(filePath) ? resolve(filePath) : resolve(filePath);
+      const abs = resolve(filePath);
       if (!existsSync(abs)) return undefined;
+      // 边界校验：仅允许工作区或剪贴板临时目录内的图片，防任意磁盘文件读取。
+      const attachmentsRoot = resolve(join(app.getPath("temp"), "zeno-attachments"));
+      const workspaceCwd = supervisor?.getWorkspaceCwd();
+      const inAttachments = abs === attachmentsRoot || abs.startsWith(attachmentsRoot + sep);
+      const inWorkspace =
+        typeof workspaceCwd === "string" && workspaceCwd.trim()
+          ? abs === resolve(workspaceCwd) || abs.startsWith(resolve(workspaceCwd) + sep)
+          : false;
+      if (!inAttachments && !inWorkspace) return undefined;
       try {
         if (!lstatSync(abs).isFile()) return undefined;
       } catch {
@@ -5504,9 +5581,10 @@ void app
     ipcMain.handle(
       "zeno:terminal:open",
       async (
-        _event,
+        event,
         options: { sessionFile: string; cwd: string; cols?: number; rows?: number },
       ) => {
+        assertTrustedSender(event);
         if (
           !options ||
           typeof options.sessionFile !== "string" ||
@@ -5661,8 +5739,10 @@ void app
     ipcMain.handle("zeno:session:import-pick", () => supervisor?.importSessionPick());
     ipcMain.handle(
       "zeno:session:bash",
-      (_event, command: string, options?: { excludeFromContext?: boolean }) =>
-        supervisor?.sessionBash(command, options),
+      (event, command: string, options?: { excludeFromContext?: boolean }) => {
+        assertTrustedSender(event);
+        return supervisor?.sessionBash(command, options);
+      },
     );
     ipcMain.handle("zeno:session:copy-last", () => supervisor?.copyLastAssistant());
     ipcMain.handle("zeno:session:share", () => supervisor?.shareSession());
@@ -5672,20 +5752,24 @@ void app
     ipcMain.handle("zeno:packages:list", () => supervisor?.listPackages());
     ipcMain.handle(
       "zeno:packages:install",
-      (_event, source: string, scope: "global" | "project", options?: { temporary?: boolean }) =>
-        supervisor?.installPackage(source, scope, options),
+      (event, source: string, scope: "global" | "project", options?: { temporary?: boolean }) => {
+        assertTrustedSender(event);
+        return supervisor?.installPackage(source, scope, options);
+      },
     );
     ipcMain.handle(
       "zeno:packages:set-enabled",
       (_event, source: string, scope: "global" | "project", enabled: boolean) =>
         supervisor?.setPackageEnabled(source, scope, enabled),
     );
-    ipcMain.handle("zeno:packages:remove", (_event, source: string, scope: "global" | "project") =>
-      supervisor?.removePackage(source, scope),
-    );
-    ipcMain.handle("zeno:packages:update", (_event, source?: string) =>
-      supervisor?.updatePackage(source),
-    );
+    ipcMain.handle("zeno:packages:remove", (event, source: string, scope: "global" | "project") => {
+      assertTrustedSender(event);
+      return supervisor?.removePackage(source, scope);
+    });
+    ipcMain.handle("zeno:packages:update", (event, source?: string) => {
+      assertTrustedSender(event);
+      return supervisor?.updatePackage(source);
+    });
     ipcMain.handle("zeno:packages:check-updates", () => supervisor?.checkPackageUpdates());
     ipcMain.handle(
       "zeno:packages:search-catalog",
@@ -5697,7 +5781,9 @@ void app
     // MCP server management — read/write mcp.json in the pi agent dir
     ipcMain.handle("zeno:mcp:get-config", () => readMcpConfig());
 
-    ipcMain.handle("zeno:mcp:install-server", async (_event, name: string, packageName: string) => {
+    ipcMain.handle("zeno:mcp:install-server", async (event, name: string, packageName: string) => {
+      assertTrustedSender(event);
+      assertNpmPackageName(packageName);
       const config = await readMcpConfig();
       // On Windows, resolve the JS entry to avoid npx-resolver's shell-script
       // detection bug.  Fall back to plain npx if resolution fails.
@@ -5708,22 +5794,22 @@ void app
       await writeMcpConfig(config);
     });
 
-    ipcMain.handle("zeno:mcp:remove-server", async (_event, name: string) => {
+    ipcMain.handle("zeno:mcp:remove-server", async (event, name: string) => {
+      assertTrustedSender(event);
       const config = await readMcpConfig();
       const server = config.mcpServers[name];
       if (server) {
         // Clean up locally installed package files so disk doesn't leak.
         try {
-          if (server.packageName) {
+          if (server.packageName && isValidNpmPackageName(server.packageName)) {
             const agentDir = defaultAgentDir();
-            const pkgDir = join(
-              agentDir,
-              "mcp-packages",
-              "node_modules",
-              ...server.packageName.split("/"),
-            );
-            if (existsSync(pkgDir)) {
-              rmSync(pkgDir, { recursive: true, force: true });
+            const mcpPackagesRoot = join(agentDir, "mcp-packages", "node_modules");
+            const pkgDir = resolve(mcpPackagesRoot, ...server.packageName.split("/"));
+            // 路径穿越防护：清理目标必须仍位于 node_modules 根目录内
+            if (pkgDir !== mcpPackagesRoot && pkgDir.startsWith(mcpPackagesRoot + sep)) {
+              if (existsSync(pkgDir)) {
+                rmSync(pkgDir, { recursive: true, force: true });
+              }
             }
           }
         } catch {
@@ -5746,10 +5832,11 @@ void app
       await writeMcpConfig(config);
     });
 
-    ipcMain.handle("zeno:mcp:update-server", async (_event, name: string) => {
+    ipcMain.handle("zeno:mcp:update-server", async (event, name: string) => {
+      assertTrustedSender(event);
       const config = await readMcpConfig();
       const server = config.mcpServers[name];
-      if (!server || !server.packageName) return;
+      if (!server || !server.packageName || !isValidNpmPackageName(server.packageName)) return;
       try {
         if (server.command === "node") {
           // Locally installed via resolveMcpNodeEntry — upgrade in place.
@@ -5768,19 +5855,11 @@ void app
             { windowsHide: true, timeout: 120_000 },
           );
         } else {
-          // npx-based — clear cache so next launch pulls the latest.
+          // npx-based — refresh to latest (pure argv, no shell interpolation).
           await execFileAsync(
-            process.platform === "win32" ? "cmd.exe" : "sh",
-            process.platform === "win32"
-              ? [
-                  "/c",
-                  `npm cache clean --force ${server.packageName} 2>nul & npx -y ${server.packageName} --version 2>nul`,
-                ]
-              : [
-                  "-c",
-                  `npm cache clean --force ${server.packageName} 2>/dev/null; npx -y ${server.packageName} --version 2>/dev/null`,
-                ],
-            { timeout: 60_000 },
+            process.platform === "win32" ? "npx.cmd" : "npx",
+            ["-y", `${server.packageName}@latest`, "--version"],
+            { windowsHide: true, timeout: 60_000 },
           );
         }
       } catch {
@@ -5798,7 +5877,10 @@ void app
     ipcMain.handle("zeno:extension-ui:respond", (_event, response: ExtensionUiResponse) =>
       supervisor?.extensionUiRespond(response),
     );
-    ipcMain.handle("zeno:test:crash-host", () => supervisor?.crashHost());
+    // 测试后门：仅开发构建暴露，生产打包不注册。
+    if (!app.isPackaged) {
+      ipcMain.handle("zeno:test:crash-host", () => supervisor?.crashHost());
+    }
 
     ipcMain.handle("zeno:notifications:show", (_event, payload: ShowOsNotificationPayload) =>
       showOsNotification(payload ?? { title: "" }),

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self' data: file: blob:; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: file: blob:; font-src 'self' data:; connect-src 'self' https: http: ws: wss:; worker-src 'self' blob:; object-src 'none'; base-uri 'none'; frame-src 'none'"
+    />
     <title>Zeno</title>
   </head>
   <body>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,8 +257,8 @@ catalogs:
       specifier: 0.525.0
       version: 0.525.0
     mermaid:
-      specifier: 11.16.0
-      version: 11.16.0
+      specifier: 11.16.1
+      version: 11.16.1
     node-pty:
       specifier: ^1.1.0
       version: 1.1.0
@@ -313,6 +313,9 @@ catalogs:
 
 overrides:
   vite: npm:@voidzero-dev/vite-plus-core@0.2.4
+  js-yaml: ~4.3.1
+  dompurify: '>=3.4.13'
+  brace-expansion@^5.0.0: '>=5.0.9'
 
 importers:
 
@@ -339,18 +342,18 @@ importers:
       '@earendil-works/pi-coding-agent':
         specifier: 'catalog:'
         version: 0.84.1(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)
-      '@zeno/agent-runtime':
-        specifier: workspace:*
-        version: link:../../packages/agent-runtime
-      '@zeno/contracts':
-        specifier: workspace:*
-        version: link:../../packages/contracts
       '@shadcn/react':
         specifier: 'catalog:'
         version: 0.2.1(@types/react@19.2.17)(react@19.2.7)
       '@silvia-odwyer/photon-node':
         specifier: 'catalog:'
         version: 0.3.4
+      '@zeno/agent-runtime':
+        specifier: workspace:*
+        version: link:../../packages/agent-runtime
+      '@zeno/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
       class-variance-authority:
         specifier: 'catalog:'
         version: 0.7.1
@@ -377,7 +380,7 @@ importers:
         version: 0.525.0(react@19.2.7)
       mermaid:
         specifier: 'catalog:'
-        version: 11.16.0
+        version: 11.16.1
       node-pty:
         specifier: 'catalog:'
         version: 1.1.0
@@ -415,9 +418,6 @@ importers:
         specifier: 'catalog:'
         version: 5.0.3(@types/react@19.2.17)(react@19.2.7)
     devDependencies:
-      '@zeno/test-utils':
-        specifier: workspace:*
-        version: link:../../packages/test-utils
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.55.0
@@ -433,6 +433,9 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
+      '@zeno/test-utils':
+        specifier: workspace:*
+        version: link:../../packages/test-utils
       electron:
         specifier: 'catalog:'
         version: 43.1.1(supports-color@7.2.0)
@@ -2415,6 +2418,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@4.0.0:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
@@ -2513,9 +2517,9 @@ packages:
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -2896,8 +2900,8 @@ packages:
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
@@ -3337,8 +3341,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-bigint@1.0.0:
@@ -3651,8 +3655,8 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
-  mermaid@11.16.0:
-    resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -6650,7 +6654,7 @@ snapshots:
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
       jiti: 2.7.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.5
@@ -6721,7 +6725,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6746,7 +6750,7 @@ snapshots:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2(supports-color@7.2.0)
       https-proxy-agent: 7.0.6(supports-color@7.2.0)
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -7126,14 +7130,14 @@ snapshots:
       app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0)
       builder-util: 26.15.3(supports-color@7.2.0)
       fs-extra: 10.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
 
   dom-accessibility-api@0.5.16: {}
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -7204,7 +7208,7 @@ snapshots:
     dependencies:
       builder-util-runtime: 9.7.0(supports-color@7.2.0)
       fs-extra: 10.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
@@ -7677,7 +7681,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -8042,7 +8046,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
-  mermaid@11.16.0:
+  mermaid@11.16.1:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.4
@@ -8056,7 +8060,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.21
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       es-toolkit: 1.49.0
       katex: 0.16.47
       khroma: 2.1.0
@@ -8281,7 +8285,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,7 +29,7 @@ catalog:
   tailwind-merge: 3.3.1
   highlight.js: 11.11.1
   katex: 0.18.1
-  mermaid: 11.16.0
+  mermaid: 11.16.1
   react-markdown: ^10.1.0
   rehype-katex: 7.0.1
   remark-gfm: ^4.0.1
@@ -45,6 +45,12 @@ catalog:
 
 overrides:
   vite: "catalog:"
+  # CVE-2026-59870 修复：electron-updater 传递依赖 js-yaml 需 >=4.3.1（限 4.x，避免 5.x 破坏 API）
+  js-yaml: "~4.3.1"
+  # GHSA-55q2-fjhq-7xh7 修复：mermaid 传递依赖 dompurify 需 >=3.4.13
+  dompurify: ">=3.4.13"
+  # GHSA-mh99-v99m-4gvg / GHSA-rgw5-rvv9-x895 修复：brace-expansion 5.x DoS（仅限 5.x，避免破坏 1.x/2.x）
+  "brace-expansion@^5.0.0": ">=5.0.9"
 
 peerDependencyRules:
   allowAny:


### PR DESCRIPTION
## 描述

对 Electron 桌面端进行代码安全审查后的加固修复，改动摘要：

- **命令注入（严重）** — `mcp:update-server` 将未校验的包名拼接进
  `sh -c` / `cmd.exe /c`；`openInApp` 将工作区路径嵌入 AppleScript / shell
  命令。两者现已改为包名白名单校验 + 纯 argv 执行，或 AppleScript
  `quoted form of` 安全引用。
- **路径穿越（严重）** — `mcp:remove-server` 可删除任意目录，
  `save-clipboard-image` 可通过 `../` 写入任意文件。两者现已做 resolve +
  前缀校验（并对图片扩展名做白名单）。
- **附件预览** — 限制在工作区与剪贴板临时目录内。
- **IPC 发送方校验** — 高权限 handler（`session.bash`、
  `packages.install/remove/update`、MCP 管理、终端、文件/外部打开、附件预览）
  现要求发送方为顶层主 frame。
- **导航锁定** — 主 frame 不再允许导航离开应用，`window.open` 被拒绝。
- **Content-Security-Policy** — 已加入渲染进程。
- **测试后门** — `crash-host` IPC 仅开发构建可用（`!app.isPackaged`）。
- **协议白名单** — `openCreatePullRequest` 仅允许 http/https/mailto。
- **依赖升级** — `mermaid` 升级到 11.16.1，并 override `dompurify`
  （>=3.4.13）、`js-yaml`（~4.3.1）、`brace-expansion@^5`（>=5.0.9）。

## 相关 issue

无 —— 主动安全加固。

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档 / 工具
- [ ] 重构（无行为变化）

## 测试

- [x] `pnpm check` 通过
- [ ] `pnpm test` 通过 —— 346/358 通过；12 个失败为 Windows 上预先存在的
      平台相关测试（Unix `tar` / `/usr/bin` / macOS `.app` 路径），与本次改动无关
- [x] `pnpm audit --prod` 报告 "No known vulnerabilities found"（此前为 9 个）
- [ ] 手动验证行为 —— 尚未在运行中的应用里做冒烟测试

## 检查清单

- [x] 代码风格与周边代码一致
- [ ] 已在可行处补充/更新测试（触及的 IPC / shell 调用路径无测试覆盖）
- [ ] 已更新文档（本次改动不影响用法或流程，N/A）
- [x] PR 标题与描述清晰并关联 issue
