### PR TITLE
fix(desktop): 修复会话渲染、流式卡顿与通知误报

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ session-*.jsonl
 
 # Local planning docs (not part of the published tree)
 docs/
+
+# Local agent knowledge (not part of the published tree)
+AGENTS.md
+.agent/

--- a/apps/desktop/src/renderer/components/MarkdownContent.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownContent.tsx
@@ -1,5 +1,14 @@
 /** Streaming-safe rich content renderer for assistant messages. */
-import { memo, useEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from "react";
+import {
+  memo,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
 import { BookMarked, Check, Copy, ExternalLink, FileCode2, Maximize2 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import rehypeKatex from "rehype-katex";
@@ -559,6 +568,29 @@ function MarkdownTable(props: {
 }
 
 export const MarkdownContent = memo(function MarkdownContent(props: {
+  children: string;
+  className?: string | undefined;
+  workspacePath?: string | undefined;
+  locale?: Locale | undefined;
+}) {
+  // Defer the expensive markdown parse during streaming. The assistant text grows
+  // token-by-token and re-parsing remark/rehype/katex on every delta stalls the
+  // renderer, producing a "stall then dump everything at once" feel. The deferred
+  // value keeps the rendered markdown one commit behind while React stays
+  // responsive and always flushes the final text.
+  const deferredText = useDeferredValue(props.children ?? "");
+  return (
+    <MarkdownContentBody
+      className={props.className}
+      workspacePath={props.workspacePath}
+      locale={props.locale}
+    >
+      {deferredText}
+    </MarkdownContentBody>
+  );
+});
+
+const MarkdownContentBody = memo(function MarkdownContentBody(props: {
   children: string;
   className?: string | undefined;
   workspacePath?: string | undefined;

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -150,6 +150,7 @@ applyThemeSelection(
   initialThemeState.sidebarTranslucent,
 );
 applyAppearancePrefs();
+const NEW_SESSION_OP_TIMEOUT_MS = 30_000;
 
 /** Surface app-level errors as a modal (agent timeline errors stay in-chat). */
 function reportAppError(error: unknown, fallback: string): string {
@@ -1032,7 +1033,7 @@ function App() {
               if (failure) {
                 store.settleSessionByRuntime(event.runtimeId, "failed", failure);
                 maybeNotify("error", failure);
-              } else {
+              } else if (store.sessionKeyForRuntime(event.runtimeId)) {
                 store.settleSessionByRuntime(event.runtimeId, "completed");
                 maybeNotify("complete");
               }
@@ -1043,7 +1044,7 @@ function App() {
                 store.takePendingFailure(event.runtimeId);
                 maybeMarkUnreadForRuntime(event.runtimeId);
                 store.settleSessionByRuntime(event.runtimeId, "aborted", event.event.message);
-                maybeNotify("error", event.event.message);
+                // User-initiated abort is not a failure — skip the "task failed" notification.
               }
               // Non-abort errors stay busy so auto-retry can re-enter recovering.
             } else if (event.event.type === "retry.started") {
@@ -1103,7 +1104,7 @@ function App() {
               store.takePendingFailure(event.runtimeId);
               maybeMarkUnreadForRuntime(event.runtimeId);
               store.settleSessionByRuntime(event.runtimeId, "aborted", event.event.message);
-              maybeNotify("error", event.event.message);
+              // User-initiated abort is not a failure — skip the "task failed" notification.
             }
             // Non-abort model errors keep the turn busy. Auto-retry emits retry.started
             // (recovering); final failure is settled by retry.ended / agent.settled.
@@ -1144,7 +1145,7 @@ function App() {
               store.setLastFailure(failure);
               store.settleSessionByRuntime(event.runtimeId, "failed", failure);
               maybeNotify("error", failure);
-            } else {
+            } else if (store.sessionKeyForRuntime(event.runtimeId)) {
               store.setLastFailure(undefined);
               store.settleSessionByRuntime(event.runtimeId, "completed");
               maybeNotify("complete");
@@ -2393,9 +2394,7 @@ function App() {
   async function newBlankTask() {
     const gen = ++newBlankTaskGenRef.current;
     // Coalesce bursts: one in-flight op; later clicks only bump gen and wait their turn.
-    if (newBlankTaskInFlightRef.current) {
-      // Let the in-flight call finish; the latest gen will re-enter via queue below.
-    }
+    if (newBlankTaskInFlightRef.current) return;
 
     // Do not abort a generating session — main parks the busy host for tab-like switching.
     if (gen !== newBlankTaskGenRef.current) return;
@@ -2432,6 +2431,16 @@ function App() {
     // flash 打开工作区以开始. pendingPureConversation drives conversation chrome instead.
 
     newBlankTaskInFlightRef.current = true;
+    const newBlankWatchdog = setTimeout(() => {
+      if (!newBlankTaskInFlightRef.current) return;
+      newBlankTaskGenRef.current += 1;
+      newBlankTaskInFlightRef.current = false;
+      pendingPureConversationRef.current = false;
+      setPendingPureConversation(false);
+      reportAppError(new Error("新建会话超时，请重试"), "无法开始新会话");
+      setTimelineReady(true);
+      pendingScrollBottomRef.current = false;
+    }, NEW_SESSION_OP_TIMEOUT_MS);
     try {
       setStatus("Creating conversation...");
       setRuntimeId(undefined);
@@ -2475,6 +2484,7 @@ function App() {
       setTimelineReady(true);
       pendingScrollBottomRef.current = false;
     } finally {
+      clearTimeout(newBlankWatchdog);
       if (gen === newBlankTaskGenRef.current) {
         newBlankTaskInFlightRef.current = false;
       }
@@ -2497,6 +2507,19 @@ function App() {
     if (newThreadForProjectInFlightRef.current) return;
 
     newThreadForProjectInFlightRef.current = true;
+
+    // Watchdog: release the in-flight gate if this op hangs (e.g. the main-process
+    // lifecycle queue is stuck while the busy host is parked), so later「新建会话」
+    // clicks can retry instead of being silently swallowed.
+    const newThreadWatchdog = setTimeout(() => {
+      if (!newThreadForProjectInFlightRef.current) return;
+      newThreadForProjectGenRef.current += 1;
+      newThreadForProjectPendingPathRef.current = null;
+      newThreadForProjectInFlightRef.current = false;
+      reportAppError(new Error("新建会话超时，请重试"), "无法在项目下新建会话");
+      setTimelineReady(true);
+      pendingScrollBottomRef.current = false;
+    }, NEW_SESSION_OP_TIMEOUT_MS);
     try {
       while (true) {
         const runGen = newThreadForProjectGenRef.current;
@@ -2557,6 +2580,7 @@ function App() {
         break;
       }
     } finally {
+      clearTimeout(newThreadWatchdog);
       newThreadForProjectInFlightRef.current = false;
       // Path queued after we cleared inFlight but before exit — pick it up.
       if (newThreadForProjectPendingPathRef.current) {

--- a/packages/agent-runtime/src/generic-renderers.ts
+++ b/packages/agent-runtime/src/generic-renderers.ts
@@ -3,6 +3,18 @@
  * Never executes TUI Component factories (message/entry/tool renderers).
  */
 
+/**
+ * Internal bookkeeping custom types that must never surface in the chat timeline.
+ * These are infrastructure entries emitted by pi/extensions (e.g. the
+ * `workspace-history` time-machine snapshots) rather than user-facing content.
+ * Showing them as "扩展 · {type}" cards also breaks the optimistic user-message
+ * dedupe (the card lands between the optimistic row and the host echo).
+ */
+const INTERNAL_CUSTOM_TYPES = new Set(["workspace-history.snapshot"]);
+
+export function isInternalCustomType(customType: string | undefined): boolean {
+  return typeof customType === "string" && INTERNAL_CUSTOM_TYPES.has(customType);
+}
 export interface GenericCustomMessageView {
   kind: "custom.message";
   customType: string;
@@ -59,6 +71,7 @@ export function projectCustomMessage(message: {
 }): GenericCustomMessageView | null {
   if (message.role !== undefined && message.role !== "custom") return null;
   if (message.display === false) return null;
+  if (isInternalCustomType(message.customType)) return null;
   if (typeof message.customType !== "string" || message.customType.length === 0) return null;
   const view: GenericCustomMessageView = {
     kind: "custom.message",
@@ -80,6 +93,7 @@ export function projectCustomEntry(entry: {
   data?: unknown;
 }): GenericCustomEntryView | null {
   if (entry.type !== undefined && entry.type !== "custom") return null;
+  if (isInternalCustomType(entry.customType)) return null;
   if (typeof entry.customType !== "string" || entry.customType.length === 0) return null;
   const view: GenericCustomEntryView = {
     kind: "custom.entry",

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -80,6 +80,7 @@ import {
 } from "./session-parity.ts";
 
 export { createPortableExtensionUiBridge } from "./extension-ui-bridge.ts";
+import { isInternalCustomType } from "./generic-renderers.ts";
 export {
   projectCustomEntry,
   projectCustomMessage,
@@ -575,6 +576,7 @@ export function projectSessionHistory(
       if (entryId) item.entryId = entryId;
       history.push(item);
     } else if (row.role === "custom") {
+      if (isInternalCustomType(row.customType)) continue;
       const text = textFromMessageContent(row.content).trim();
       const item: SessionHistoryMessage = {
         role: "system",

--- a/packages/agent-runtime/test/extension-reload-render.test.ts
+++ b/packages/agent-runtime/test/extension-reload-render.test.ts
@@ -217,6 +217,30 @@ describe("U05 generic custom renderers", () => {
     expect(sanitizeSerializable({ a: () => 1, b: "ok" })).toEqual({ b: "ok" });
   });
 
+  it("drops internal bookkeeping custom types (workspace-history.snapshot)", () => {
+    expect(
+      projectCustomMessage({
+        role: "custom",
+        customType: "workspace-history.snapshot",
+        content: [{ type: "text", text: '{"v":1,"kind":"baseline"}' }],
+        display: true,
+      }),
+    ).toBeNull();
+
+    expect(
+      projectCustomEntry({
+        type: "custom",
+        customType: "workspace-history.snapshot",
+        data: { v: 1, kind: "baseline", commit: "abc123", createdAt: "2026-08-14T00:00:00.000Z" },
+      }),
+    ).toBeNull();
+
+    // Unrelated custom types still project normally.
+    expect(
+      projectCustomMessage({ role: "custom", customType: "status-update", content: "ok" }),
+    ).toMatchObject({ kind: "custom.message", customType: "status-update" });
+  });
+
   it("projects custom messages from a live extension without executing renderers", async () => {
     const root = await mkdtemp(join(tmpdir(), "zeno-ext-render-"));
     temporaryDirectories.push(root);

--- a/packages/agent-runtime/test/session-history.test.ts
+++ b/packages/agent-runtime/test/session-history.test.ts
@@ -233,4 +233,20 @@ describe("session history projection", () => {
       }),
     ).toEqual([{ role: "user", text: "first", entryId: "u1" }]);
   });
+
+  it("drops internal workspace-history snapshot custom entries", () => {
+    expect(
+      projectSessionHistory(
+        [
+          {
+            role: "custom",
+            customType: "workspace-history.snapshot",
+            content: [{ type: "text", text: '{"v":1,"kind":"baseline"}' }],
+          },
+          { role: "user", content: "hello" },
+        ],
+        ["snapshot-entry", "user-entry"],
+      ),
+    ).toEqual([{ role: "user", text: "hello", entryId: "user-entry" }]);
+  });
 });


### PR DESCRIPTION
## 描述

本次改动修复三个桌面端会话体验问题，并加固新建会话流程：

1. **过滤内部快照条目**：`pi-workspace-history` 扩展写入的 `workspace-history.snapshot` 内部记账条目会被渲染为「扩展 · workspace-history.snapshot」卡片，且插在乐观用户行与 host 回显之间，破坏按末项去重的逻辑，导致同一输入显示两份。现在在投影层过滤这类内部 `customType`。

2. **优化流式渲染卡顿**：流式输出逐 token 增长，每个 delta 都重新解析 markdown（remark/rehype/katex），表现为「卡一下再一次性涌出」。改用 `useDeferredValue` + memo 化的 `MarkdownContentBody`，解析按可中断的低优先级节奏刷新。

3. **修正主动终止误报通知**：用户主动终止会触发 `message.failed(reason="aborted")` 与随后的 `agent.settled`，此前会误发「任务失败」和「任务完成」系统通知。现在主动终止不再发通知，界面只显示「已停止」状态。

4. **新建会话看门狗**：为新建会话操作增加 30s 超时看门狗，避免主进程生命周期队列卡住时 in-flight 门闩永不释放、后续点击被静默吞掉。

## 变更类型

- [x] Bug 修复
- [x] 性能优化

## 测试

- [x] `pnpm check` 通过（`pnpm check:types` + `pnpm fmt`，282 文件无 lint/type/格式问题）
- [x] 相关单测通过：
  - `agent-runtime`：extension-reload-render + session-history（14/14）
  - `desktop`：markdown-content（8/8）、live-stream + timeline（30/30）、shell-store + timeline（28/28）
- [x] 已打包 Windows portable 并手动验证

## 检查清单

- [x] 代码风格与周边一致
- [x] 已补充/更新测试
- [x] PR 标题与描述清晰
